### PR TITLE
correct pdns.conf permissions on Redhat derivatives

### DIFF
--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -19,3 +19,4 @@ powerdns::recursor_configdir: /etc/pdns-recursor
 powerdns::recursor_config: "%{lookup('powerdns::recursor_configdir')}/recursor.conf"
 powerdns::recursor_package_name: pdns-recursor
 powerdns::recursor_service_name: pdns-recursor
+powerdns::authoritative_group: 'pdns'

--- a/manifests/authoritative.pp
+++ b/manifests/authoritative.pp
@@ -1,6 +1,6 @@
 # powerdns::authoritative
-class powerdns::authoritative (
-) inherits powerdns {
+#
+class powerdns::authoritative inherits powerdns {
   # install the powerdns package
   package { $powerdns::authoritative_package_name:
     ensure => $powerdns::authoritative_package_ensure,
@@ -9,6 +9,14 @@ class powerdns::authoritative (
   stdlib::ensure_packages($powerdns::authoritative_extra_packages, { 'ensure' => $powerdns::authoritative_extra_packages_ensure })
 
   include "powerdns::backends::${powerdns::backend}"
+
+  file { $powerdns::authoritative_config:
+    ensure => 'file',
+    owner  => 'root',
+    group  => $powerdns::authoritative_group,
+    mode   => '0640',
+    before => Service['pdns'],
+  }
 
   service { 'pdns':
     ensure  => running,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,9 @@
 # @param lmdb_sync_mode
 #   Sync mode for LMDB. One of 'nosync', 'sync', 'nometasync', 'mapasync'
 #
+# @param authoritative_group
+#   If present, this group will be set on the authoritative server pdns.conf file. 
+#
 class powerdns (
   String[1] $authoritative_package_name,
   String[1] $authoritative_package_ensure,
@@ -65,6 +68,7 @@ class powerdns (
   Hash $forward_zones = {},
   Powerdns::Autoprimaries $autoprimaries = {},
   Boolean $purge_autoprimaries = false,
+  Optional[String[1]] $authoritative_group = undef,
 ) {
   # Do some additional checks. In certain cases, some parameters are no longer optional.
   if $authoritative {

--- a/spec/classes/powerdns_init_spec.rb
+++ b/spec/classes/powerdns_init_spec.rb
@@ -131,6 +131,17 @@ describe 'powerdns', type: :class do
           it { is_expected.to contain_service('pdns').with('enable' => 'true') }
           it { is_expected.to contain_service('pdns').with('name' => authoritative_service_name) }
           it { is_expected.to contain_service('pdns').that_requires("Package[#{authoritative_package_name}]") }
+
+          it do
+            is_expected.to contain_file(authoritative_config).with(
+              ensure: 'file',
+              owner: 'root',
+              mode: '0640',
+            ).that_comes_before('Service[pdns]')
+          end
+          if facts[:os]['family'] == 'RedHat'
+            it { is_expected.to contain_file(authoritative_config).with(group: 'pdns') }
+          end
         end
 
         context 'powerdns class with epel' do


### PR DESCRIPTION
The permissions on the `/etc/pdns/pdns.conf` file do not allow the service to read it when using the standard pdns user on Rocky9. 

This PR changes the permissions on the file such that the pdns service can read, but not write to it. This allows the service to start correctly.

There were originally other changes in this PR, however, they have been merged and are now nolonger needed.