### PR TITLE
update recursor version to 5.0, authoritative version to 4.9

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,6 +1,6 @@
 ---
 powerdns::authoritative_package_ensure: installed
 powerdns::authoritative_extra_packages_ensure: installed
-powerdns::authoritative_version: '4.8'
+powerdns::authoritative_version: '4.9'
 powerdns::recursor_package_ensure: installed
-powerdns::recursor_version: '4.9'
+powerdns::recursor_version: '5.0'

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -44,7 +44,7 @@ describe 'powerdns class' do
     end
 
     describe command('/usr/bin/pdns_control version') do
-      its(:stdout) { is_expected.to match %r{^4\.8} }
+      its(:stdout) { is_expected.to match %r{^4\.9} }
     end
   end
 

--- a/spec/classes/powerdns_init_spec.rb
+++ b/spec/classes/powerdns_init_spec.rb
@@ -109,18 +109,18 @@ describe 'powerdns', type: :class do
           case facts[:osfamily]
           when 'RedHat'
             it { is_expected.to contain_yumrepo('powerdns') }
-            it { is_expected.to contain_yumrepo('powerdns').with('baseurl' => 'http://repo.powerdns.com/centos/$basearch/$releasever/auth-48') }
+            it { is_expected.to contain_yumrepo('powerdns').with('baseurl' => 'http://repo.powerdns.com/centos/$basearch/$releasever/auth-49') }
             it { is_expected.to contain_yumrepo('powerdns-recursor') }
-            it { is_expected.to contain_yumrepo('powerdns-recursor').with('baseurl' => 'http://repo.powerdns.com/centos/$basearch/$releasever/rec-49') }
+            it { is_expected.to contain_yumrepo('powerdns-recursor').with('baseurl' => 'http://repo.powerdns.com/centos/$basearch/$releasever/rec-50') }
           end
           case facts[:osfamily]
           when 'Debian'
             it { is_expected.to contain_apt__key('powerdns') }
             it { is_expected.to contain_apt__pin('powerdns') }
             it { is_expected.to contain_apt__source('powerdns') }
-            it { is_expected.to contain_apt__source('powerdns').with_release(%r{auth-48}) }
+            it { is_expected.to contain_apt__source('powerdns').with_release(%r{auth-49}) }
             it { is_expected.to contain_apt__source('powerdns-recursor') }
-            it { is_expected.to contain_apt__source('powerdns-recursor').with_release(%r{rec-49}) }
+            it { is_expected.to contain_apt__source('powerdns-recursor').with_release(%r{rec-50}) }
             it { is_expected.to contain_package('dirmngr') }
           end
 


### PR DESCRIPTION
Otherwise, tests are failing on Ubuntu 24.04, as the upstream repo isn't available 