### PR TITLE
allow puppetlabs/mysql 16.X

### DIFF
--- a/data/os/Debian/11.yaml
+++ b/data/os/Debian/11.yaml
@@ -1,0 +1,3 @@
+---
+powerdns::mysql_charset: utf8
+powerdns::mysql_collate: utf8_general_ci

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -9,6 +9,8 @@ powerdns::ldap_backend_package_name: pdns-backend-ldap
 powerdns::pgsql_backend_package_name: pdns-backend-postgresql
 powerdns::sqlite_backend_package_name: pdns-backend-sqlite
 powerdns::lmdb_backend_package_name: pdns-backend-lmdb
+powerdns::mysql_charset: utf8
+powerdns::mysql_collate: utf8_general_ci
 powerdns::sqlite_package_name: sqlite
 powerdns::authoritative_package_name: pdns
 powerdns::authoritative_extra_packages: []

--- a/manifests/backends/mysql.pp
+++ b/manifests/backends/mysql.pp
@@ -75,6 +75,8 @@ class powerdns::backends::mysql (
       password => $powerdns::db_password,
       host     => $powerdns::db_host,
       grant    => ['ALL'],
+      charset  => $powerdns::mysql_charset,
+      collate  => $powerdns::mysql_collate,
       sql      => [$powerdns::mysql_schema_file],
       require  => Package[$powerdns::mysql_backend_package_name],
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,8 @@ class powerdns (
   Optional[String[1]] $pgsql_backend_package_name = undef,
   Optional[String[1]] $sqlite_backend_package_name = undef,
   Optional[String[1]] $lmdb_backend_package_name = undef,
+  Optional[String[1]] $mysql_charset = undef,
+  Optional[String[1]] $mysql_collate = undef,
   Boolean $authoritative = true,
   Boolean $recursor = false,
   Powerdns::Backends $backend = 'mysql',

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/mysql",
-      "version_requirement": ">= 15.0.0 < 16.0.0"
+      "version_requirement": ">= 15.0.0 < 17.0.0"
     },
     {
       "name": "puppetlabs/postgresql",


### PR DESCRIPTION
charset and collate will be set for some supported OSes, as otherwise acceptance tests are failing due to corrective changes, see https://github.com/puppetlabs/puppetlabs-mysql/issues/1639