### PR TITLE
Fix resource ordering for sqlite backend

### DIFF
--- a/manifests/backends/sqlite.pp
+++ b/manifests/backends/sqlite.pp
@@ -33,10 +33,11 @@ class powerdns::backends::sqlite (
   }
   if $powerdns::backend_create_tables {
     file { $powerdns::db_dir:
-      ensure => directory,
-      mode   => '0755',
-      owner  => 'pdns',
-      group  => 'pdns',
+      ensure  => directory,
+      mode    => '0755',
+      owner   => 'pdns',
+      group   => 'pdns',
+      require => Package[$powerdns::authoritative_package_name],
     }
     -> file { $powerdns::db_file:
       ensure => file,
@@ -48,7 +49,6 @@ class powerdns::backends::sqlite (
       command => "/usr/bin/env sqlite3 ${powerdns::db_file} < ${powerdns::sqlite_schema_file}",
       unless  => "/usr/bin/env test `echo '.tables domains' | sqlite3 ${powerdns::db_file} | wc -l` -eq 1",
       before  => Service['pdns'],
-      require => Package[$powerdns::authoritative_package_name],
     }
   }
 }


### PR DESCRIPTION
`pdns` user & group don't exist before the package is installed.
