### PR TITLE
 Add support for YAML config files on Ubuntu 24.04 and 22.04

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,10 +1,14 @@
 ---
+lookup_options:
+  powerdns::recursor_local_config:
+    merge: deep
 powerdns::authoritative_package_ensure: installed
 powerdns::authoritative_extra_packages_ensure: installed
-powerdns::authoritative_version: '4.9'
+powerdns::authoritative_version: "4.9"
 powerdns::recursor_package_ensure: installed
-powerdns::recursor_version: '5.0'
+powerdns::recursor_version: "5.0"
 powerdns::recursor_user: pdns
 powerdns::recursor_group: pdns
 powerdns::recursor_file_owner: root
 powerdns::recursor_file_group: "%{lookup('powerdns::recursor_group')}"
+powerdns::recursor_use_yaml: false

--- a/data/os/Ubuntu/22.04.yaml
+++ b/data/os/Ubuntu/22.04.yaml
@@ -1,0 +1,8 @@
+---
+powerdns::authoritative_version: "5.0"
+powerdns::recursor_version: "5.3"
+powerdns::recursor_use_yaml: true
+powerdns::recursor_config: "%{lookup('powerdns::recursor_configdir')}/recursor.yml"
+powerdns::recursor_config_includedir: "%{lookup('powerdns::recursor_configdir')}/recursor.d"
+powerdns::recursor_forward_zones_file: "%{lookup('powerdns::recursor_configdir')}/forward-zones.yml"
+powerdns::recursor_local_config_file: "%{lookup('powerdns::recursor_config_includedir')}/00-local.yml"

--- a/data/os/Ubuntu/24.04.yaml
+++ b/data/os/Ubuntu/24.04.yaml
@@ -1,0 +1,8 @@
+---
+powerdns::authoritative_version: "5.0"
+powerdns::recursor_version: "5.3"
+powerdns::recursor_use_yaml: true
+powerdns::recursor_config: "%{lookup('powerdns::recursor_configdir')}/recursor.yml"
+powerdns::recursor_config_includedir: "%{lookup('powerdns::recursor_configdir')}/recursor.d"
+powerdns::recursor_forward_zones_file: "%{lookup('powerdns::recursor_configdir')}/forward-zones.yml"
+powerdns::recursor_local_config_file: "%{lookup('powerdns::recursor_config_includedir')}/00-local.yml"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -132,7 +132,7 @@ class powerdns (
   String[1] $authoritative_service_name,
   Stdlib::Absolutepath $authoritative_configdir,
   Stdlib::Absolutepath $authoritative_config,
-  Pattern[/4\.[0-9]+/] $authoritative_version,
+  Pattern[/[4,5]\.[0-9]+/] $authoritative_version,
   Stdlib::Absolutepath $db_file,
   Stdlib::Absolutepath $mysql_schema_file,
   Stdlib::Absolutepath $pgsql_schema_file,
@@ -142,6 +142,9 @@ class powerdns (
   String[1] $recursor_service_name,
   Stdlib::Absolutepath $recursor_configdir,
   Stdlib::Absolutepath $recursor_config,
+  Stdlib::Absolutepath $recursor_config_includedir,
+  Stdlib::Absolutepath $recursor_forward_zones_file,
+  Stdlib::Absolutepath $recursor_local_config_file,
   String[1] $recursor_user,
   String[1] $recursor_group,
   String[1] $recursor_file_owner,
@@ -157,6 +160,9 @@ class powerdns (
   Optional[String[1]] $mysql_collate = undef,
   Boolean $authoritative = true,
   Boolean $recursor = false,
+  Boolean $recursor_use_yaml = false,
+  Optional[Hash] $recursor_local_config = undef,
+  Optional[Tuple] $recursor_forward_zones = undef,
   Powerdns::Backends $backend = 'mysql',
   Boolean $backend_install = true,
   Boolean $backend_create_tables = true,
@@ -226,7 +232,9 @@ class powerdns (
     # Set up Hiera for the recursor.
     $powerdns_recursor_config = lookup('powerdns::recursor::config', Hash, 'deep', {})
     $powerdns_recursor_defaults = { 'type' => 'recursor' }
-    create_resources(powerdns::config, $powerdns_recursor_config, $powerdns_recursor_defaults)
+    if !($recursor_use_yaml) {
+      create_resources(powerdns::config, $powerdns_recursor_config, $powerdns_recursor_defaults)
+    }
   }
 
   if $purge_autoprimaries {

--- a/manifests/recursor.pp
+++ b/manifests/recursor.pp
@@ -10,29 +10,95 @@ class powerdns::recursor (
     ensure => $powerdns::recursor_package_ensure,
   }
 
-  file { $powerdns::recursor_config:
-    ensure  => file,
-    owner   => $powerdns::recursor_file_owner,
-    group   => $powerdns::recursor_file_group,
-    require => Package[$powerdns::recursor_package_name],
-  }
+  if $powerdns::recursor_use_yaml {
+    ## Use New YAML based configuration
+    $forward_block = empty($powerdns::recursor_forward_zones) ? {
+      true  => {},
+      false => { 'forward_zones_file' => $powerdns::recursor_forward_zones_file },
+    }
 
-  if !empty($forward_zones) {
-    $zone_config = "${powerdns::recursor_configdir}/forward_zones.conf"
-    file { $zone_config:
+    $recursor_config = {
+      'recursor' => {
+        'include_dir' => $powerdns::recursor_config_includedir,
+      } + $forward_block,
+    }
+
+    if !empty($powerdns::recursor_forward_zones) {
+      file { $powerdns::recursor_forward_zones_file:
+        ensure  => file,
+        owner   => $powerdns::recursor_file_owner,
+        group   => $powerdns::recursor_file_group,
+        content => to_yaml($powerdns::recursor_forward_zones),
+        notify  => Service['pdns-recursor'],
+      }
+    }
+    file { $powerdns::recursor_config_includedir:
+      ensure  => directory,
+      owner   => $powerdns::recursor_file_owner,
+      group   => $powerdns::recursor_file_group,
+      require => Package[$powerdns::recursor_package_name],
+    }
+
+    file { $powerdns::recursor_config:
       ensure  => file,
       owner   => $powerdns::recursor_file_owner,
       group   => $powerdns::recursor_file_group,
-      content => template('powerdns/forward_zones.conf.erb'),
+      content => to_yaml($recursor_config),
+      require => Package[$powerdns::recursor_package_name],
       notify  => Service['pdns-recursor'],
     }
 
-    powerdns::config { 'forward-zones-file':
-      value => $zone_config,
-      type  => 'recursor',
+    file { $powerdns::recursor_local_config_file:
+      ensure  => file,
+      owner   => $powerdns::recursor_file_owner,
+      group   => $powerdns::recursor_file_group,
+      content => to_yaml(lookup('powerdns::recursor_local_config', Data, 'deep', {})),
+      require => Package[$powerdns::recursor_package_name],
+      notify  => Service['pdns-recursor'],
+    }
+  } else {
+    ## Use Old INI based configuration
+    file { $powerdns::recursor_config_includedir:
+      ensure  => directory,
+      owner   => $powerdns::recursor_file_owner,
+      group   => $powerdns::recursor_file_group,
+      require => Package[$powerdns::recursor_package_name],
+    }
+
+    file { $powerdns::recursor_config:
+      ensure       => file,
+      owner        => $powerdns::recursor_file_owner,
+      group        => $powerdns::recursor_file_group,
+      content      => to_yaml(
+        'recursor' => { 'include_dir' => $powerdns::recursor_config_includedir }
+      ),
+      require      => Package[$powerdns::recursor_package_name],
+      notify       => Service['pdns-recursor'],
+    }
+
+    file { $powerdns::recursor_local_config_file:
+      ensure       => file,
+      owner        => $powerdns::recursor_file_owner,
+      group        => $powerdns::recursor_file_group,
+      content      => to_yaml(
+        'recursor' => lookup('powerdns::recursor::local_config', Hash, 'deep', {})
+      ),
+      require      => Package[$powerdns::recursor_package_name],
+      notify       => Service['pdns-recursor'],
+    }
+
+    if !empty($powerdns::recursor_forward_zones) {
+      file { $powerdns::recursor_forward_zones_file:
+        ensure       => file,
+        owner        => $powerdns::recursor_file_owner,
+        group        => $powerdns::recursor_file_group,
+        content      => to_yaml(
+          'recursor' => { 'forward-zones' => $forward_zones }
+        ),
+        notify       => Service['pdns-recursor'],
+      }
     }
   }
-
   service { 'pdns-recursor':
     ensure  => running,
     name    => $powerdns::recursor_service_name,

--- a/metadata.json
+++ b/metadata.json
@@ -53,6 +53,7 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
+        "22.04",
         "24.04"
       ]
     },


### PR DESCRIPTION
#### Pull Request (PR) description

Add YAML config file support for Recursor, since going forward legacy config is deprecated, and you can no longer say you support 24.04 without supporting YAML or some way to trigger the `--enable-old-settings` flag.

This is uniquely restricted to 24.04 and 22.04 (which I added back to the supported releases; why it was removed is not exactly clear).

If others want to add support for Redhat/Arch/etc, that'd be great; as I have no functional way to test those.

I also recognize this will require some Readme changes, but I didn't want to tackle those without some level of acceptance here.

#### This Pull Request (PR) fixes the following issues
Fixes #172 